### PR TITLE
Updates for Silex 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
   },
   "require": {
     "php": ">=5.4",
-    "silex/silex": "~1.2"
+    "silex/silex": "~2.0"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.3",

--- a/src/rootLogin/JSRoutingProvider/Provider/SilexJSRoutingControllerProvider.php
+++ b/src/rootLogin/JSRoutingProvider/Provider/SilexJSRoutingControllerProvider.php
@@ -4,7 +4,7 @@ namespace rootLogin\JSRoutingProvider\Provider;
 
 use rootLogin\JSRoutingProvider\JSRoutingProvider;
 use Silex\Application;
-use Silex\ControllerProviderInterface;
+use Silex\Api\ControllerProviderInterface;
 use Symfony\Component\HttpFoundation\Response;
 
 class SilexJSRoutingControllerProvider implements ControllerProviderInterface

--- a/src/rootLogin/JSRoutingProvider/Provider/SilexJSRoutingServiceProvider.php
+++ b/src/rootLogin/JSRoutingProvider/Provider/SilexJSRoutingServiceProvider.php
@@ -2,14 +2,16 @@
 
 namespace rootLogin\JSRoutingProvider\Provider;
 
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use rootLogin\JSRoutingProvider\Command\DumpJSCommand;
 use rootLogin\JSRoutingProvider\Command\DumpRouterCommand;
+use Silex\Api\BootableProviderInterface;
 use Silex\Application;
-use Silex\ServiceProviderInterface;
 
-class SilexJSRoutingServiceProvider implements ServiceProviderInterface
+class SilexJSRoutingServiceProvider implements ServiceProviderInterface, BootableProviderInterface
 {
-    public function register(Application $app)
+    public function register(Container $app)
     {
         foreach ($this->getDefaults() as $key => $value) {
             if (!isset($app[$key])) {


### PR DESCRIPTION
Fixes #2 

Changelog for Silex 2.0: http://silex.sensiolabs.org/doc/master/changelog.html#id5

It looks like the changes to the interfaces in 2.0 were BC breaks, so I removed the `~1.2` dependency for silex/silex as I assume these changes would break silex < 2.0.